### PR TITLE
Fix tortoise beacon config

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -83,17 +83,17 @@
     "refresh-ntp-interval": "30m"
   },
   "tortoise-beacon": {
-    "tortoise-beacon-first-voting-round-duration-ms": 60000,
-    "tortoise-beacon-grace-period-duration-ms": 10000,
+    "tortoise-beacon-first-voting-round-duration": "60s",
+    "tortoise-beacon-grace-period-duration": "10s",
     "tortoise-beacon-kappa": 400000,
-    "tortoise-beacon-proposal-duration-ms": 30000,
+    "tortoise-beacon-proposal-duration": "30s",
     "tortoise-beacon-q": "1/3",
     "tortoise-beacon-rounds-number": 6,
-    "tortoise-beacon-theta": 0.00004,
+    "tortoise-beacon-theta": "1/25000",
     "tortoise-beacon-votes-limit": 100,
-    "tortoise-beacon-voting-round-duration-ms": 50000,
-    "tortoise-beacon-wait-after-epoch-start-ms": 1000,
-    "tortoise-beacon-weak-coin-round-duration-ms": 1000
+    "tortoise-beacon-voting-round-duration": "50s",
+    "tortoise-beacon-wait-after-epoch-start": "50s",
+    "tortoise-beacon-weak-coin-round-duration": "10s"
   },
   "smeshing": {
     "smeshing-opts": {


### PR DESCRIPTION
Tortoise beacon config format was changed in https://github.com/spacemeshos/go-spacemesh/pull/2650. This pull request fixes the tortoise beacon config format and changes some values there (waiting after epoch start duration, weak coin round duration)